### PR TITLE
Improve search suggestion load timings

### DIFF
--- a/app/src/main/java/io/ningyuan/palantir/MainActivity.java
+++ b/app/src/main/java/io/ningyuan/palantir/MainActivity.java
@@ -2,9 +2,6 @@ package io.ningyuan.palantir;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.text.Html;
-import android.text.method.LinkMovementMethod;
-import android.widget.EditText;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -67,9 +64,5 @@ public class MainActivity extends AppCompatActivity {
 
     public void showAbout() {
         aboutView.show();
-    }
-
-    public void hideAbout() {
-        aboutView.hide();
     }
 }

--- a/app/src/main/java/io/ningyuan/palantir/utils/PdbSearcher.java
+++ b/app/src/main/java/io/ningyuan/palantir/utils/PdbSearcher.java
@@ -1,16 +1,14 @@
 package io.ningyuan.palantir.utils;
 
-import android.app.SearchManager;
 import android.database.MatrixCursor;
 import android.os.AsyncTask;
-import android.provider.BaseColumns;
 import android.util.Log;
 import android.view.View;
 import android.widget.CursorAdapter;
 import android.widget.ProgressBar;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -19,10 +17,15 @@ import io.ningyuan.jPdbApi.Pdb;
 import io.ningyuan.jPdbApi.Query;
 import io.ningyuan.palantir.views.SearchView;
 
-public class PdbSearcher extends AsyncTask<String, Void, MatrixCursor> {
+/**
+ * Represents a search instance. For example, at the instance when 'insul' is just keyed into the
+ * searchView's EditText, a PdbSearcher instance is formed for 'insul'. However, when 'insuli' is
+ * keyed in, the 'insul' PdbSearcher instance is invalidated in favour of the new 'insuli' instance.
+ */
+public class PdbSearcher extends AsyncTask<String, Void, LinkedList<Pdb>> {
     private static final String TAG = String.format("PALANTIR::%s", PdbSearcher.class.getSimpleName());
-    private boolean inProgress = false;
 
+    private boolean valid = true;
     private CursorAdapter adapter;
     private ProgressBar progressBar;
 
@@ -31,8 +34,15 @@ public class PdbSearcher extends AsyncTask<String, Void, MatrixCursor> {
         this.progressBar = progressBar;
     }
 
-    public boolean isRunning() {
-        return inProgress;
+    public boolean isValid() {
+        return valid;
+    }
+
+    /**
+     * The parent SearchView has been deactivated, or a newer PdbSearcher was spawned.
+     */
+    public void makeInvalid() {
+        valid = false;
     }
 
     @Override
@@ -41,31 +51,30 @@ public class PdbSearcher extends AsyncTask<String, Void, MatrixCursor> {
         if (progressBar != null) {
             progressBar.setVisibility(View.VISIBLE);
         }
-        inProgress = true;
     }
 
     @Override
-    protected MatrixCursor doInBackground(String... queryStrings) {
+    protected LinkedList<Pdb> doInBackground(String... queryStrings) {
         String queryString = queryStrings[0];
 
         try {
             Query query = new Query(Query.KEYWORD_QUERY, queryString);
             List<String> results = query.execute();
-            MatrixCursor cursor = SearchView.getEmptyCursor(false);
-            int index = 1;
+            LinkedList<Pdb> pdbResults = new LinkedList<>();
             Log.i(TAG, String.format("Start doInBackground for %s", queryString));
             for (String pdbId : results) {
-                Log.d(TAG, String.format("Fetching %s for %s", pdbId, queryString));
-                Pdb pdb = new Pdb(pdbId);
-                try {
-                    pdb.load();
-                    cursor.addRow(new Object[]{index++, pdb.getStructureId(), pdb.getTitle()});
-                } catch (FileNotFoundException e) {
-                    Log.e(TAG, String.format("Encountered an exception for %s.", queryString), e);
-                }
+                ((LinkedList<Pdb>) pdbResults).addLast(new Pdb(pdbId));
+                // TODO: do this later, after just the pdbIds are passed to UI
+                // Log.d(TAG, String.format("Fetching %s for %s", pdbId, queryString));
+                // Pdb pdb = new Pdb(pdbId);
+                // try {
+                //     pdb.load();
+                //     cursor.addRow(new Object[]{index++, pdb.getStructureId(), pdb.getTitle()});
+                // } catch (FileNotFoundException e) {
+                //     Log.e(TAG, String.format("Encountered an exception for %s.", queryString), e);
+                // }
             }
-
-            return cursor;
+            return pdbResults;
         } catch (IOException | ParserConfigurationException e) {
             Log.e(TAG, String.format("Encountered an exception for %s.", queryString), e);
             return null;
@@ -73,26 +82,25 @@ public class PdbSearcher extends AsyncTask<String, Void, MatrixCursor> {
     }
 
     @Override
-    protected void onPostExecute(MatrixCursor cursor) {
-        inProgress = false;
+    protected void onPostExecute(LinkedList<Pdb> results) {
         if (progressBar != null) {
             progressBar.setVisibility(View.INVISIBLE);
         }
 
-        if (cursor == null) {
-            String[] columns = {
-                    BaseColumns._ID,
-                    SearchManager.SUGGEST_COLUMN_TEXT_1,
-                    SearchManager.SUGGEST_COLUMN_TEXT_2
-            };
-            cursor = new MatrixCursor(columns);
+        MatrixCursor cursor = SearchView.getEmptyCursor(false);
+        int cursorIndex = 0;
+        for (Pdb pdb : results) {
+            cursor.addRow(new Object[]{
+                    cursorIndex++, pdb.getStructureId(), pdb.getTitle()
+            });
         }
-
         adapter.changeCursor(cursor);
+
+        new PdbTitleSearcher(this, adapter, results).execute(0);
     }
 
     @Override
-    protected void onCancelled(MatrixCursor cursor) {
+    protected void onCancelled(LinkedList<Pdb> results) {
         // On cancelled, do nothing. I make this explicit because method used to set the progressBar
         // visibility to View.INVISIBLE. That was not a good idea: when a search was cancelled and
         // another started in its place immediately, a race condition was created. One would expect
@@ -101,6 +109,6 @@ public class PdbSearcher extends AsyncTask<String, Void, MatrixCursor> {
         // often called before onCancelled, so the progressBar would not show. Instead, I set the
         // progressBar visibility to View.INVISIBLE explicitly in the SearchView methods.
         Log.d(TAG, "onCancelled called.");
-        inProgress = false;
+        makeInvalid();
     }
 }

--- a/app/src/main/java/io/ningyuan/palantir/utils/PdbTitleSearcher.java
+++ b/app/src/main/java/io/ningyuan/palantir/utils/PdbTitleSearcher.java
@@ -1,0 +1,59 @@
+package io.ningyuan.palantir.utils;
+
+import android.database.MatrixCursor;
+import android.os.AsyncTask;
+import android.util.Log;
+import android.widget.CursorAdapter;
+
+import java.io.IOException;
+import java.util.LinkedList;
+
+import io.ningyuan.jPdbApi.Pdb;
+import io.ningyuan.palantir.views.SearchView;
+
+/**
+ * Represents the lazy loading of titles for each result in a PdbSearcher.
+ */
+public class PdbTitleSearcher extends AsyncTask<Integer, Void, Integer> {
+    private static final String TAG = String.format("PALANTIR::%s", PdbTitleSearcher.class.getSimpleName());
+
+    private LinkedList<Pdb> pdbs;
+    private CursorAdapter adapter;
+    private PdbSearcher pdbSearcher;
+
+    public PdbTitleSearcher(PdbSearcher pdbSearcher, CursorAdapter adapter, LinkedList<Pdb> pdbs) {
+        this.adapter = adapter;
+        this.pdbSearcher = pdbSearcher;
+        this.pdbs = pdbs;
+    }
+
+    @Override
+    protected Integer doInBackground(Integer... integers) {
+        int indexToLoad = integers[0];
+
+        try {
+            pdbs.get(indexToLoad).load();
+        } catch (IOException e) {
+            Log.e(TAG, null, e);
+        }
+
+        return indexToLoad + 1;
+    }
+
+    @Override
+    protected void onPostExecute(Integer nextIndex) {
+        MatrixCursor cursor = SearchView.getEmptyCursor(false);
+        int cursorIndex = 0;
+        for (Pdb pdb : pdbs) {
+            cursor.addRow(new Object[]{
+                    cursorIndex++, pdb.getStructureId(), pdb.getTitle()
+            });
+        }
+        adapter.changeCursor(cursor);
+
+        Log.d(TAG, String.format("pdbSearcher.isValid()=%b", pdbSearcher.isValid()));
+        if (nextIndex < pdbs.size() && pdbSearcher.isValid()) {
+            new PdbTitleSearcher(pdbSearcher, adapter, pdbs).execute(nextIndex);
+        }
+    }
+}

--- a/app/src/main/java/io/ningyuan/palantir/views/SearchView.java
+++ b/app/src/main/java/io/ningyuan/palantir/views/SearchView.java
@@ -141,7 +141,6 @@ public class SearchView extends android.widget.SearchView {
         });
     }
 
-
     private void deactivate() {
         // Clear the soft keyboard
         clearFocus();
@@ -163,9 +162,10 @@ public class SearchView extends android.widget.SearchView {
         Log.d(TAG, String.format("doSearch found \"%s\"", query));
         if (query.length() < 3) {
             MatrixCursor cursor = getEmptyCursor();
-            suggestionAdapter.swapCursor(cursor);
+            suggestionAdapter.changeCursor(cursor);
         } else {
             pdbSearcher.cancel(true);
+            pdbSearcher.makeInvalid();  // pdbSearcher.onCancelled not called if doInBackground already complete
             pdbSearcher = new PdbSearcher(suggestionAdapter, progressBar);
             Log.i(TAG, String.format("Starting search with %s", query));
             pdbSearcher.execute(query);


### PR DESCRIPTION
Resolves #21---the search suggestions were not failing to load, but the progressBar was failing to show up because of a race condition in the previous search setting the progressBar invisible (when it was cancelled in favour of the upcoming search to replace it) versus the newer seaerch setting the progressBar visible.

Resolved this, and then separated the retrieval of search results and the fetching of titles of said search results. That is, previously, these two items:

- A list of PDB IDs matching the text search, and
- Titles of the PDB entry, for each aforementioned PDB ID

had to be fully loaded before being rendered as search suggestions. Now, only the first item needs to be retrieved before it is shown as search suggestion (a list of PDB IDs). Then, another AsyncTask is spawned to fetch the title of each PDB entry.